### PR TITLE
predict.py script added with a minimal change of other files

### DIFF
--- a/GUI_main.py
+++ b/GUI_main.py
@@ -744,18 +744,18 @@ class App(QMainWindow):
         self.reader.SaveMask(timeindex, fovindex, seg)
         print('--------- Finished segmenting.')
           
-          
-    def LaunchPrediction(self, im, is_pc):
+    @staticmethod   
+    def LaunchPrediction(im, is_pc, pretrained_weights=None):
         """It launches the neural neutwork on the current image and creates 
         an hdf file with the prediction for the time T and corresponding FOV. 
         """
         im = skimage.exposure.equalize_adapthist(im)
         im = im*1.0;	
-        pred = nn.prediction(im, is_pc)                        
+        pred = nn.prediction(im, is_pc, pretrained_weights)                        
         return pred
 
-
-    def ThresholdPred(self, thvalue, pred):     
+    @staticmethod
+    def ThresholdPred(thvalue, pred):     
         """Thresholds prediction with value"""
         if thvalue == None:
             thresholdedmask = nn.threshold(pred)

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sun Jul 17 17:00:11 2021
+Author: stojk
+
+"""
+import sys
+sys.path.append("./unet")
+sys.path.append("./disk")
+
+#Import all the other python files
+#this file handles the interaction with the disk, so loading/saving images
+#and masks and it also runs the neural network.
+
+import Reader as nd
+import argparse
+from GUI_main import App
+import skimage
+import neural_network as nn
+from segment import segment
+
+
+def LaunchInstanceSegmentation(reader, imaging_type, fov_indices=[0], time_value1=0, time_value2=0, thr_val=None, seg_val=10, weights_path=None):
+    """
+    """
+
+    # check if correct imaging value
+    if imaging_type not in ['bf', 'pc']:
+        print("Wrong imaging type value ('{}')!".format(imaging_type),
+              "imaging type must be either 'bf' or 'pc'")
+        return
+    is_pc = imaging_type == 'pc'
+
+    # check timepoints constraint
+    if time_value1 > time_value2 :
+        print("Error", 'Invalid Time Constraints')
+        return
+    
+    # displays that the neural network is running
+    print('Running the neural network...')
+    
+    for fov_ind in fov_indices:
+
+        #iterates over the time indices in the range
+        for t in range(time_value1, time_value2+1):         
+            print('--------- Segmenting field of view:',fov_ind,'Time point:',t)
+
+            #calls the neural network for time t and selected fov
+            im = reader.LoadOneImage(t, fov_ind)
+
+            try:
+                pred = App.LaunchPrediction(im, is_pc, pretrained_weights=weights_path)
+            except ValueError:
+                print('Error! ',
+                      'The neural network weight files could not '
+                      'be found. \nMake sure to download them from '
+                      'the link in the readme and put them into '
+                      'the folder unet, or specify a path to a custom weights file with -w argument.')
+                return
+
+            thresh = App.ThresholdPred(thr_val, pred)
+            seg = segment(thresh, pred, seg_val)
+            reader.SaveMask(t, fov_ind, seg)
+            print('--------- Finished segmenting.')
+            
+            # apply tracker if wanted and if not at first time
+            temp_mask = reader.CellCorrespondence(t, fov_ind)
+            reader.SaveMask(t, fov_ind, temp_mask)
+
+def main(args):
+
+    if '.h5' in args.mask_path:
+        args.mask_path = args.mask_path.replace('.h5','')
+
+    reader = nd.Reader("", args.mask_path, args.image_path)
+
+    LaunchInstanceSegmentation(reader, args.imaging_type, args.fovs,
+                               args.timepoints[0],  args.timepoints[1], args.threshold, args.segmentation, args.weights_path)
+
+if __name__ == '__main__':
+    
+    parser = argparse.ArgumentParser(description='', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('-i', '--image_path', type=str, help="Specify the single image path or images folder path", required=True)
+    parser.add_argument('-m', '--mask_path', type=str, help="Specify where to save predicted masks", required=True)
+    parser.add_argument('-t', '--imaging_type', type=str, help="Specify the imaging type, possible 'bf' and 'pc'")
+    parser.add_argument('-w', '--weights_path', default=None, type=str, help="Specify weights path")
+    parser.add_argument('--fovs', default=[0], nargs='+', type=int, help="Specify fovs")
+    parser.add_argument('--timepoints', nargs=2, default=[0,0], type=int, help="Specify start and end timepoints")
+    parser.add_argument('--threshold', default=None, type=float, help="Specify threshold value")
+    parser.add_argument('--segmentation', default=10, type=float, help="Specify segmentation value")
+    args = parser.parse_args()
+    main(args)

--- a/unet/neural_network.py
+++ b/unet/neural_network.py
@@ -46,7 +46,7 @@ def threshold(im,th = None):
     return bi
 
 
-def prediction(im, is_pc):
+def prediction(im, is_pc, pretrained_weights=None):
     """
     Calculate the prediction of the label corresponding to image im
     Param:
@@ -60,19 +60,18 @@ def prediction(im, is_pc):
     col_add = 16-ncol%16
     padded = np.pad(im, ((0, row_add), (0, col_add)))
     
-    # WHOLE CELL PREDICTION
-    model = unet(pretrained_weights = None,
-                 input_size = (None,None,1))
-
-    if is_pc:
-        path = path_weights + 'unet_weights_batchsize_25_Nepochs_100_SJR0_10.hdf5'
-    else:
-        path = path_weights + 'unet_weights_BF_batchsize_25_Nepochs_100_SJR_0_1.hdf5'
+    if pretrained_weights is None:
+        if is_pc:
+            pretrained_weights = path_weights + 'unet_weights_batchsize_25_Nepochs_100_SJR0_10.hdf5'
+        else:
+            pretrained_weights = path_weights + 'unet_weights_BF_batchsize_25_Nepochs_100_SJR_0_1.hdf5'
     
-    if not os.path.exists(path):
+    if not os.path.exists(pretrained_weights):
         raise ValueError('Path does not exist')
-    
-    model.load_weights(path)
+
+    # WHOLE CELL PREDICTION
+    model = unet(pretrained_weights = pretrained_weights,
+                 input_size = (None,None,1))
 
     results = model.predict(padded[np.newaxis,:,:,np.newaxis], batch_size=1)
 


### PR DESCRIPTION
Hi @lpbsscientist, 

This pull request contains new predict.py script, that will allow users to run instance segmentation prediction without the need of starting the GUI. 

Users can specify the same arguments present in the GUI: 
- image or image folder path (-i, --image_path)
- mask path (-m, --mask_path)
- imaging type (-t, --imaging_type)
- fields of views (e.g. --fovs 0 1 3 5)
- timepoints (e.g. --timepoints 0 10)
- detection threshold (e.g. --threshold 0.5)
- segmentation value (e.g. --segmentation 10)

 I've also added a possibility for users to directly specify a path for their custom weights file with the argument '-w' or '--weights_path'. Specifying this path will override the default weights specified by imaging type argument. 